### PR TITLE
Add option to include/exclude Entity Type Code in generated output

### DIFF
--- a/src/XrmContext/CodeDom/XrmCodeDom.fs
+++ b/src/XrmContext/CodeDom/XrmCodeDom.fs
@@ -346,10 +346,10 @@ let MakeEntity (entity: XrmEntity) =
     entity.opt_sets |> List.partition (fun optionSet -> optionSet.isGlobal)
 
   let relatedOptionSetEnums =
-    relatedOptionSets |> List.map MakeEntityOptionSet
+    relatedOptionSets |> List.map MakeEntityOptionSet |> List.sortBy (fun o -> o.Name)
 
   let globalOptionSetEnums =
-    globalOptionSets |> List.map MakeEntityOptionSet
+    globalOptionSets |> List.map MakeEntityOptionSet |> List.sortBy (fun o -> o.Name)
 
   cl, relatedOptionSetEnums, globalOptionSetEnums
   

--- a/src/XrmContext/CodeDom/XrmCodeDom.fs
+++ b/src/XrmContext/CodeDom/XrmCodeDom.fs
@@ -300,7 +300,7 @@ let MakeEntity (entity: XrmEntity) =
   // Add static members
   cl.Members.AddRange(EntityConstructors()) |> ignore
   cl.Members.Add(Constant "EntityLogicalName" entity.logicalName) |> ignore
-  cl.Members.Add(Constant "EntityTypeCode" entity.typecode) |> ignore
+  if entity.typecode.IsSome then cl.Members.Add(Constant "EntityTypeCode" entity.typecode.Value) |> ignore
   cl.Members.Add(DebuggerDisplayMember entity.primaryNameAttribute) |> ignore
 
   // Static retrieve methods

--- a/src/XrmContext/CommandLine/Arguments.fs
+++ b/src/XrmContext/CommandLine/Arguments.fs
@@ -61,6 +61,12 @@ type Args private () =
       altCommands=["of"]
       description="Set to false to generate one file per entity instead of one big file."
       required=false }
+
+    { command = "includeEntityTypeCode";
+      altCommands=["ietc"]
+      description = "Set to false to prevent generation of an Entity Type Code constant in each entity definition. Default is true."
+      required=false }
+
     ]
 
   static member connectionArgs = [

--- a/src/XrmContext/CommandLine/Program.fs
+++ b/src/XrmContext/CommandLine/Program.fs
@@ -75,6 +75,7 @@ let getGenerationSettings parsedArgs =
     intersections = intersections
     labelMapping = labelMapping
     oneFile = getArg parsedArgs "oneFile" parseBoolish ?| true
+    includeEntityTypeCode = getArg parsedArgs "includeEntityTypeCode" parseBoolish ?| true
   }
 
 /// Load metadata from local file and generate

--- a/src/XrmContext/Domain.fs
+++ b/src/XrmContext/Domain.fs
@@ -36,6 +36,7 @@ type XcGenerationSettings = {
   intersections: EntityIntersect[] option
   labelMapping: (string * string)[] option
   oneFile: bool
+  includeEntityTypeCode: bool
 }
 
 type XcRetrievalSettings = {

--- a/src/XrmContext/Generation/Setup.fs
+++ b/src/XrmContext/Generation/Setup.fs
@@ -78,7 +78,7 @@ let interpretCrmData (gSettings: XcGenerationSettings) out sdkVersion (rawState:
 
   let entityMetadata =
     publicEntities
-    |> Array.Parallel.map (interpretEntity entityNames entityMap entityToIntersects gSettings.deprecatedPrefix gSettings.labelMapping sdkVersion)
+    |> Array.Parallel.map (interpretEntity entityNames entityMap entityToIntersects gSettings.deprecatedPrefix gSettings.labelMapping gSettings.includeEntityTypeCode sdkVersion)
     |> Array.sortBy (fun x -> x.schemaName)
 
 

--- a/src/XrmContext/IntermediateRepresentation.fs
+++ b/src/XrmContext/IntermediateRepresentation.fs
@@ -50,7 +50,7 @@ type XrmAlternateKey = {
 }
 
 type XrmEntity = {
-  typecode: int
+  typecode: int option
   schemaName: string
   logicalName: string
   description: string list option

--- a/src/XrmContext/Interpretation/InterpretEntityMetadata.fs
+++ b/src/XrmContext/Interpretation/InterpretEntityMetadata.fs
@@ -184,7 +184,7 @@ let interpretKeyAttribute attrTypeMap (keyMetadata:EntityKeyMetadata) =
   }
 
 
-let interpretEntity entityNames entityMap entityToIntersects deprecatedPrefix labelmapping sdkVersion (metadata:EntityMetadata) =
+let interpretEntity entityNames entityMap entityToIntersects deprecatedPrefix labelmapping includeEntityTypeCode sdkVersion (metadata:EntityMetadata) =
   if (metadata.Attributes = null) then failwith "No attributes found!"
 
   // Attributes and option sets
@@ -243,7 +243,7 @@ let interpretEntity entityNames entityMap entityToIntersects deprecatedPrefix la
   let desc = getDescription (getLabelOption metadata.DisplayName) metadata.Description
 
   // Return the entity representation
-  { XrmEntity.typecode = metadata.ObjectTypeCode.GetValueOrDefault()
+  { XrmEntity.typecode = if includeEntityTypeCode then Some(metadata.ObjectTypeCode.GetValueOrDefault()) else None
     description = desc
     schemaName = metadata.SchemaName
     logicalName = metadata.LogicalName

--- a/src/XrmContext/XrmContext.fs
+++ b/src/XrmContext/XrmContext.fs
@@ -11,7 +11,7 @@ open System.Runtime.Serialization.Json
 
 type XrmContext private () =
 
-  static member GenerateFromCrm(url, ?method, ?username, ?password, ?domain, ?ap, ?mfaAppId, ?mfaReturnUrl, ?mfaClientSecret, ?connectionString, ?out, ?entities, ?solutions, ?ns, ?context, ?deprecatedPrefix, ?sdkVersion, ?intersections,?labelMapping, ?oneFile) = 
+  static member GenerateFromCrm(url, ?method, ?username, ?password, ?domain, ?ap, ?mfaAppId, ?mfaReturnUrl, ?mfaClientSecret, ?connectionString, ?out, ?entities, ?solutions, ?ns, ?context, ?deprecatedPrefix, ?sdkVersion, ?intersections,?labelMapping, ?oneFile, ?includeEntityTypeCode) = 
     let xrmAuth = 
       { XrmAuthentication.url = Uri(url)
         method = method
@@ -38,6 +38,7 @@ type XrmContext private () =
         intersections = intersections
         labelMapping = labelMapping
         oneFile = oneFile ?| true
+        includeEntityTypeCode = includeEntityTypeCode ?| true
        }
     
     XrmContext.GenerateFromCrm(xrmAuth, rSettings, gSettings)


### PR DESCRIPTION
Here's a PR for the change we discussed to allow you to pass a command line argument to include/exclude the entity type code in the generated output.